### PR TITLE
Fix Game Over & Main Menu Screens

### DIFF
--- a/Assets/Scenes/GameOver.unity
+++ b/Assets/Scenes/GameOver.unity
@@ -295,7 +295,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -220, y: -161}
+  m_AnchoredPosition: {x: -201, y: -130}
   m_SizeDelta: {x: 300, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &294585149
@@ -421,7 +421,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &427214273
 RectTransform:
   m_ObjectHideFlags: 0
@@ -834,10 +834,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1998548346}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 28, y: 28}
-  m_SizeDelta: {x: -479, y: -388}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 6, y: 31}
+  m_SizeDelta: {x: 213, y: 2}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &550119882
 MonoBehaviour:
@@ -868,8 +868,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4286283263
-  m_fontColor: {r: 1, g: 0.49038127, b: 0.48113203, a: 1}
+    rgba: 4293190884
+  m_fontColor: {r: 0.89433956, g: 0.89433956, b: 0.89433956, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -886,8 +886,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 28
+  m_fontSizeBase: 28
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -922,7 +922,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: -52.20871, y: 0, z: 0, w: 0}
+  m_margin: {x: -52.20871, y: 0, z: -140.83495, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -1435,7 +1435,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 276, y: -161}
+  m_AnchoredPosition: {x: 235, y: -132}
   m_SizeDelta: {x: 300, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1366239141
@@ -1646,7 +1646,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -145, y: -54}
+  m_AnchoredPosition: {x: -111, y: -45}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1553457282
@@ -1737,6 +1737,140 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a354cbcfe4427e54bb80a937ac8fc70a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1677594804
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1677594805}
+  - component: {fileID: 1677594807}
+  - component: {fileID: 1677594806}
+  m_Layer: 5
+  m_Name: Game
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1677594805
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677594804}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.05, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1998548346}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -60, y: 35}
+  m_SizeDelta: {x: 528, y: 57}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &1677594806
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677594804}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Gam
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3d8de3c858d8dc94eb08c41fbf595496, type: 2}
+  m_sharedMaterial: {fileID: -9148045913423941052, guid: 3d8de3c858d8dc94eb08c41fbf595496, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967172
+  m_fontColor: {r: 0.51886785, g: 1, b: 0.9990888, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -2.24292, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1677594807
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677594804}
+  m_CullTransparentMesh: 1
 --- !u!1 &1700854673
 GameObject:
   m_ObjectHideFlags: 0
@@ -1865,6 +1999,140 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!1 &1722344410
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1722344411}
+  - component: {fileID: 1722344413}
+  - component: {fileID: 1722344412}
+  m_Layer: 5
+  m_Name: Over
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1722344411
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1722344410}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.05, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1998548346}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 90, y: 36}
+  m_SizeDelta: {x: 528, y: 57}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &1722344412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1722344410}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: e Over!
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3d8de3c858d8dc94eb08c41fbf595496, type: 2}
+  m_sharedMaterial: {fileID: -9148045913423941052, guid: 3d8de3c858d8dc94eb08c41fbf595496, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967172
+  m_fontColor: {r: 0.51886785, g: 1, b: 0.9990888, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -2.24292, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1722344413
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1722344410}
+  m_CullTransparentMesh: 1
 --- !u!1 &1841038015
 GameObject:
   m_ObjectHideFlags: 0
@@ -1933,7 +2201,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 13, y: -39}
+  m_AnchoredPosition: {x: 8, y: -27}
   m_SizeDelta: {x: -479, y: -388}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1864363518
@@ -1965,8 +2233,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4286283519
-  m_fontColor: {r: 1, g: 0.49411765, b: 0.48235294, a: 1}
+    rgba: 4278191871
+  m_fontColor: {r: 1, g: 0.022727273, b: 0, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -2019,7 +2287,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_margin: {x: 0, y: 0, z: -63.01941, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -2050,7 +2318,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1888595100
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2268,6 +2536,8 @@ RectTransform:
   - {fileID: 1577803732}
   - {fileID: 427214273}
   - {fileID: 1888595100}
+  - {fileID: 1677594805}
+  - {fileID: 1722344411}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -285,7 +285,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 127, y: 28}
+  m_AnchoredPosition: {x: 133, y: 36}
   m_SizeDelta: {x: 528, y: 57}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &226311970
@@ -317,8 +317,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+    rgba: 4294967044
+  m_fontColor: {r: 0.015686275, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -451,8 +451,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4294705042
-  m_fontColor: {r: 0.57169807, g: 1, b: 0.9852129, a: 1}
+    rgba: 4286774195
+  m_fontColor: {r: 0.70186186, g: 0.98490566, b: 0.5110359, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -623,7 +623,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 24, y: 2}
+  m_AnchoredPosition: {x: 51, y: 2}
   m_SizeDelta: {x: 310, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &722830708
@@ -1264,7 +1264,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 365510416605662232, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 20
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 365510416605662232, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -1279,12 +1279,16 @@ PrefabInstance:
       value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 702748449275337374, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 702748449275337374, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 302
+      value: 281
       objectReference: {fileID: 0}
     - target: {fileID: 702748449275337374, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -163
+      value: -131
       objectReference: {fileID: 0}
     - target: {fileID: 1252849949290177211, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_LocalScale.x
@@ -1332,11 +1336,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2074054550402269230, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -269
+      value: -213
       objectReference: {fileID: 0}
     - target: {fileID: 2074054550402269230, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -162
+      value: -134
       objectReference: {fileID: 0}
     - target: {fileID: 2201392029263107731, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_Pivot.y
@@ -1368,11 +1372,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2201392029263107731, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -89
+      value: -83
       objectReference: {fileID: 0}
     - target: {fileID: 2201392029263107731, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 27
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 2308976674536683858, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_LocalScale.x
@@ -1425,6 +1429,10 @@ PrefabInstance:
     - target: {fileID: 2350477917864170065, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_LocalScale.y
       value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2350477917864170065, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2350477917864170065, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -1507,6 +1515,14 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4603802824360004400, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4603802824360004400, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4603802824360004400, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.4
       objectReference: {fileID: 0}
@@ -1516,11 +1532,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4603802824360004400, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -145
+      value: -111
       objectReference: {fileID: 0}
     - target: {fileID: 4603802824360004400, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -54
+      value: -45
       objectReference: {fileID: 0}
     - target: {fileID: 4646917425722207649, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -1782,6 +1798,14 @@ PrefabInstance:
       propertyPath: m_text
       value: Skullyw
       objectReference: {fileID: 0}
+    - target: {fileID: 8056337360447398209, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
+      propertyPath: m_fontColor.r
+      value: 0.015686275
+      objectReference: {fileID: 0}
+    - target: {fileID: 8056337360447398209, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967044
+      objectReference: {fileID: 0}
     - target: {fileID: 8162944976526134566, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_text
       value: << Play >>
@@ -1792,7 +1816,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8162944976526134566, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_fontColor.b
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8162944976526134566, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_fontColor.g
@@ -1800,7 +1824,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8162944976526134566, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_fontColor.r
-      value: 0.46457553
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8162944976526134566, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_fontSizeBase
@@ -1808,7 +1832,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8162944976526134566, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_fontColor32.rgba
-      value: 4278255478
+      value: 4294967295
       objectReference: {fileID: 0}
     - target: {fileID: 8162944976526134566, guid: 6095dd0a904f54041a28128d101d7b1d, type: 3}
       propertyPath: m_HorizontalAlignment


### PR DESCRIPTION
I don't know why but when I pulled the most recent repo today and opened the screens, they were all resized and messed up. Fixed and added "Game Over" to the game over screen (lol). Will look for a different background for it too. Attaching screenshots of what they look like,

![Game-Over-0204](https://github.com/TwoLittleWitches/COMP397-Pirate-Game/assets/94991789/1a4b0b02-8cc4-42ef-9a54-3dec7c53d5a0)
![Main-Menu-0204](https://github.com/TwoLittleWitches/COMP397-Pirate-Game/assets/94991789/37b5eb95-b773-4b56-b9b6-11fd695edf51)
